### PR TITLE
Added quick bug fix to mdb_date_to_readable() to handle invalid epoch…

### DIFF
--- a/access_parser/utils.py
+++ b/access_parser/utils.py
@@ -30,14 +30,19 @@ ACCESS_EPOCH = datetime(1899, 12, 30)
 
 # https://stackoverflow.com/questions/45560782
 def mdb_date_to_readable(double_time):
-    dtime_bytes = struct.pack("Q", double_time)
+    try:
+        dtime_bytes = struct.pack("Q", double_time)
 
-    dtime_double = struct.unpack('<d', dtime_bytes)[0]
-    dtime_frac, dtime_whole = math.modf(dtime_double)
-    dtime = (ACCESS_EPOCH + timedelta(days=dtime_whole) + timedelta(days=dtime_frac))
-    if dtime == ACCESS_EPOCH:
-        return "(Empty Date)"
-    return str(dtime)
+        dtime_double = struct.unpack('<d', dtime_bytes)[0]
+        dtime_frac, dtime_whole = math.modf(dtime_double)
+        dtime = (ACCESS_EPOCH + timedelta(days=dtime_whole) + timedelta(days=dtime_frac))
+        if dtime == ACCESS_EPOCH:
+            return "(Empty Date)"
+        return str(dtime)
+    except OverflowError:
+        return "(Invalid Date)"
+    except struct.error:
+        return "(Invalid Date)"
 
 
 def numeric_to_string(bytes_num, scale=6):


### PR DESCRIPTION
… numbers

Dealing with a messy database some epoch values were crazy: negative, or numbers too big for C int. This just excepts those two errors and returns invalid date.