### PR TITLE
Add support for non-UTF8 encoded databases

### DIFF
--- a/access_parser/utils.py
+++ b/access_parser/utils.py
@@ -59,7 +59,7 @@ def numeric_to_string(bytes_num, scale=6):
     return numeric_string
 
 
-def parse_type(data_type, buffer, length=None, version=3):
+def parse_type(data_type, buffer, length=None, version=3, config=None):
     parsed = ""
     # Bool or int8
     if data_type == TYPE_INT8:
@@ -95,7 +95,8 @@ def parse_type(data_type, buffer, length=None, version=3):
             else:
                 parsed = buffer.decode("utf-16", errors='ignore')
         else:
-            parsed = buffer.decode('utf-8', errors='ignore')
+            charset = config.jet3_charset if config else 'utf-8'
+            parsed = buffer.decode(charset, errors='ignore')
     else:
         logging.debug(f"parse_type - unsupported data type: {data_type}")
     return parsed


### PR DESCRIPTION
I was trying to parse some .mdb file and I noticed that it is incorrectly decoding text from non-UTF8 encoded databases. In my case, ISO-8859-2 encoded.

I found this note in mdbtools `HACKING.md`
> In Jet3, the encoding of text depends on the machine on which it was created. So for databases created on U.S. English systems, it can be expected that text is encoded in CP1252. This is the default used by mdbtools. If you know that another encoding has been used, you can override the default by setting the environment variable MDB_JET3_CHARSET. To find out what encodings will work on your system, run 'iconv -l'.
(https://github.com/mdbtools/mdbtools/blob/master/HACKING.md#text-data-type)

So I added a configuration option to change the default "utf-8" charset. There was no config before, so let me know if you think that it should be passed differently.